### PR TITLE
Fixed starting session for sessions whose name does not match key

### DIFF
--- a/src/js/Components/LoginWindow/Userbar/Session.jsx
+++ b/src/js/Components/LoginWindow/Userbar/Session.jsx
@@ -11,7 +11,7 @@ class Session extends React.Component {
             this.auth_event = () => {
                 if (lightdm.is_authenticated) {
                     this.props.success();
-                    lightdm.start_session(this.props.session.name);
+                    lightdm.start_session(this.props.session.key);
                 } else {notify("Wrong password!", types.Error); this.props.failure();}
             };
         }


### PR DESCRIPTION
I couldn't log in with this (great looking) theme, so I dug around a bit and it seems like start_session is supposed to take the session key instead of name (at least according to the provided themes in web-greeter).

Problematic session was Plasma (Wayland).  I'm not 100% sure this is the correct fix, so please try it with your session to make sure it still works.

And thanks for the theme.